### PR TITLE
Remove unnecessary `VERSION` specification

### DIFF
--- a/src/ChangePrecision.jl
+++ b/src/ChangePrecision.jl
@@ -1,5 +1,3 @@
-VERSION < v"0.7.0-beta2.199" && __precompile__()
-
 """
 The `ChangePrecision` module exports a macro `@changeprecision T expression`
 that changes the "default" floating-point precision in a given `expression`
@@ -222,18 +220,13 @@ end
 ^(T, x::Union{AbstractMatrix{<:Promotable},Promotable}, y::Union{RatLike,Complex{<:HWInt}}) = Base.:^(tofloat(T, x), y)
 
 # e^x is handled specially
-const esym = VERSION < v"0.7.0-DEV.1592" ? :e : :ℯ # changed in JuliaLang/julia#23427
+const esym = :ℯ # changed in JuliaLang/julia#23427
 ^(T, x::Irrational{esym}, y::Promotable) = Base.exp(tofloat(T, y))
 literal_pow(T, op, x::Irrational{esym}, ::Val{n}) where {n} = Base.exp(tofloat(T, n))
 
 # literal integer powers are specially handled in Julia
-if VERSION < v"0.7.0-DEV.843" # JuliaLang/julia#22475
-    literal_pow(T, op, x::Irrational, ::Val{n}) where {n} = Base.literal_pow(op, tofloat(T, x), Val{n})
-    @inline literal_pow(T, op, x, ::Val{n}) where {n} = Base.literal_pow(op, x, Val{n})
-else
-    literal_pow(T, op, x::Irrational, p) = Base.literal_pow(op, tofloat(T, x), p)
-    @inline literal_pow(T, op, x, p) = Base.literal_pow(op, x, p)
-end
+literal_pow(T, op, x::Irrational, p) = Base.literal_pow(op, tofloat(T, x), p)
+@inline literal_pow(T, op, x, p) = Base.literal_pow(op, x, p)
 
 for f in (statfuncs...,linalgfuncs...)
     m = f ∈ statfuncs ? :Statistics : :LinearAlgebra

--- a/src/ChangePrecision.jl
+++ b/src/ChangePrecision.jl
@@ -220,9 +220,8 @@ end
 ^(T, x::Union{AbstractMatrix{<:Promotable},Promotable}, y::Union{RatLike,Complex{<:HWInt}}) = Base.:^(tofloat(T, x), y)
 
 # e^x is handled specially
-const esym = :ℯ # changed in JuliaLang/julia#23427
-^(T, x::Irrational{esym}, y::Promotable) = Base.exp(tofloat(T, y))
-literal_pow(T, op, x::Irrational{esym}, ::Val{n}) where {n} = Base.exp(tofloat(T, n))
+^(T, x::Irrational{:ℯ}, y::Promotable) = Base.exp(tofloat(T, y))
+literal_pow(T, op, x::Irrational{:ℯ}, ::Val{n}) where {n} = Base.exp(tofloat(T, n))
 
 # literal integer powers are specially handled in Julia
 literal_pow(T, op, x::Irrational, p) = Base.literal_pow(op, tofloat(T, x), p)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,8 +38,6 @@ end
     @test @changeprecision(Float32, angle(1+0im)) === Float32(0)
 end
 
-const euler = ℯ # changed in JuliaLang/julia#23427
-
 @testset "irrational" begin
     @test @changeprecision(Float32, sqrt(pi)) === sqrt(Float32(pi))
     @test @changeprecision(Float32, pi/3) === Float32(pi)/3
@@ -50,7 +48,7 @@ const euler = ℯ # changed in JuliaLang/julia#23427
     @test @changeprecision(Float32, 2*2*2*2*2*Float32(pi)) === @changeprecision(Float32,Float32(pi)*2*2*2*2*2)=== 32*Float32(pi)
     @test @changeprecision(Float32, pi^2) === Float32(pi)^2
     @test @changeprecision(Float32, pi^2) === Float32(pi)^2
-    @test @changeprecision(Float32, euler^2) === @changeprecision(Float32, euler^(3-1)) === exp(Float32(2))
+    @test @changeprecision(Float32, ℯ^2) === @changeprecision(Float32, ℯ^(3-1)) === exp(Float32(2))
 end
 
 @testset "powers" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,7 @@ end
     @test @changeprecision(Float32, angle(1+0im)) === Float32(0)
 end
 
-const euler = VERSION < v"0.7.0-DEV.1592" ? e : ℯ # changed in JuliaLang/julia#23427
+const euler = ℯ # changed in JuliaLang/julia#23427
 
 @testset "irrational" begin
     @test @changeprecision(Float32, sqrt(pi)) === sqrt(Float32(pi))


### PR DESCRIPTION
The `[compat]` in `Project.toml` specifies `julia = 1`, so the `VERSION` comparisons with `v"0.7.*"` can be removed.